### PR TITLE
Fix - Frontend: LoginForm username space

### DIFF
--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -8,7 +8,8 @@ import {
   Text,
   TextInput,
 } from '@mantine/core';
-import React from 'react';
+
+import React, { useState } from 'react';
 import { Form } from 'ui';
 import * as z from 'zod';
 
@@ -31,6 +32,11 @@ type LoginFormProps = {
 
 export const LoginForm = ({ onSuccess }: LoginFormProps) => {
   const login = useLogin();
+  const [inputValue, setInputValue] = useState('');
+  const handleInputChange = (event) => {
+    const newValue = event.target.value.replace(/\s/g, ''); // Remove spaces using regex
+    setInputValue(newValue);
+  };
 
   return (
     <StyledContainer>
@@ -49,6 +55,8 @@ export const LoginForm = ({ onSuccess }: LoginFormProps) => {
             <>
               <Stack>
                 <TextInput
+                  value={inputValue}
+                  onInput={handleInputChange}
                   label="Username"
                   placeholder="Enter your username"
                   required


### PR DESCRIPTION
## Ticket/s

- [Login Functionality-API Integration](https://trello.com/c/iHNABA3f/48-login-functionality-api-integration)

## Changes

- Add onInput handler to Mantine - TextInput for username

## Screenshot

- 
![image](https://github.com/dandalandone/POC-EyCommerce/assets/132859942/f5d95bf8-bfd7-4d20-854e-db0885c77768)


## How to test?

- Access login page - http://localhost:5173/login
- Space should not be accepted anymore in the username field