### PR TITLE
[Frontend] Cart dropdown in header

### DIFF
--- a/apps/web/src/views/SampleView.tsx
+++ b/apps/web/src/views/SampleView.tsx
@@ -10,7 +10,6 @@ export const SampleView = () => {
       <section style={{ height: '100vh' }}>
         <div>
           <br />
-          <Quantity />
           <Searchbar />
           <Product />
         </div>

--- a/packages/ui/cart/Cart.tsx
+++ b/packages/ui/cart/Cart.tsx
@@ -1,0 +1,72 @@
+import {
+  Divider,
+  Image,
+  Text,
+  Group,
+  Flex,
+  Container,
+  Paper,
+  Anchor,
+} from '@mantine/core';
+import { TiTrash } from 'react-icons/ti';
+
+interface ICartProps {
+  imageSrc: string;
+  merchant: string;
+  productName: string;
+  price: number;
+}
+
+const Cart: React.FC<ICartProps> = ({
+  imageSrc,
+  merchant,
+  productName,
+  price,
+}) => {
+  return (
+    <div>
+      <Paper shadow="xs" radius="lg" p="md">
+        <Flex align="flex-start" gap="xs" justify="flex-start">
+          <div>
+            <Image
+              width={120}
+              height={120}
+              src={imageSrc}
+              alt="With default placeholder"
+              withPlaceholder
+            />
+          </div>
+          <div>
+            <Text ta="left" fz="sm" c="dimmed">
+              {merchant}
+            </Text>
+            <Text fz="sm">{productName}</Text>
+            <Text fz="lg" fw={500} color="yellow">
+              {price.toFixed(2)}
+            </Text>
+          </div>
+        </Flex>
+        <Divider my="sm" />
+        <Group position="right" spacing="xs">
+          <Anchor href="#" target="_blank">
+            <Text fw={500} color="black">
+              Move to Favorites
+            </Text>
+          </Anchor>
+          <Divider orientation="vertical" />
+          <Anchor href="#" target="_blank">
+            <Text fw={500} color="yellow">
+              Edit
+            </Text>
+          </Anchor>
+          <Divider orientation="vertical" />
+          <Anchor href="#" target="_blank">
+            <TiTrash size={22} color="grey" />
+          </Anchor>
+        </Group>
+      </Paper>
+    </div>
+  );
+};
+
+export default Cart;

--- a/packages/ui/cart/Cart.tsx
+++ b/packages/ui/cart/Cart.tsx
@@ -10,6 +10,8 @@ import {
 } from '@mantine/core';
 import { TiTrash } from 'react-icons/ti';
 
+import { Quantity } from '../quantity/Quantity';
+
 interface ICartProps {
   imageSrc: string;
   merchant: string;
@@ -42,8 +44,9 @@ const Cart: React.FC<ICartProps> = ({
             </Text>
             <Text fz="sm">{productName}</Text>
             <Text fz="lg" fw={500} color="yellow">
-              {price.toFixed(2)}
+              ₱{price.toFixed(2)}
             </Text>
+            <Quantity />
           </div>
         </Flex>
         <Divider my="sm" />

--- a/packages/ui/cart/HeaderCart.tsx
+++ b/packages/ui/cart/HeaderCart.tsx
@@ -1,0 +1,91 @@
+import {
+  Menu,
+  UnstyledButton,
+  Text,
+  Flex,
+  Button,
+  Anchor,
+} from '@mantine/core';
+import { TiShoppingCart } from 'react-icons/ti';
+import Cart from './Cart';
+
+interface ICartItem {
+  id: number;
+  imageSrc: string;
+  merchant: string;
+  productName: string;
+  price: number;
+}
+interface IHeaderCartProps {
+  cartItems: ICartItem[];
+}
+const HeaderCart: React.FC<IHeaderCartProps> = ({ cartItems }) => {
+  return (
+    <Menu shadow="md" width={400}>
+      <Menu.Target>
+        <UnstyledButton>
+          <TiShoppingCart color="#fab005" size={36} />
+        </UnstyledButton>
+      </Menu.Target>
+      <Menu.Dropdown style={{ maxHeight: '575px', overflowY: 'auto' }}>
+        <Menu.Label
+          style={{
+            position: 'sticky',
+            top: -4,
+            background: '#fff',
+            zIndex: 2,
+            padding: '10px 0px',
+          }}
+        >
+          <Text fz="lg" color="black">
+            <Flex align="center" justify="space-between">
+              <div>
+                <Flex>
+                  <Text fw={700}>My Cart</Text>
+                  <Text>&nbsp;(4)</Text>
+                </Flex>
+              </div>
+              <Anchor href="#" target="_blank">
+                <Text fz="sm" color="yellow">
+                  View all
+                </Text>
+              </Anchor>
+            </Flex>
+          </Text>
+        </Menu.Label>
+        <Menu.Divider />
+        {cartItems.map((item) => (
+          <Menu.Item key={item.id}>
+            <Cart
+              imageSrc={item.imageSrc}
+              merchant={item.merchant}
+              productName={item.productName}
+              price={item.price}
+            />
+          </Menu.Item>
+        ))}
+        <Menu.Divider />
+        <Menu.Label
+          style={{
+            position: 'sticky',
+            bottom: -4,
+            background: '#fff',
+            zIndex: 2,
+            padding: '10px 0',
+          }}
+        >
+          <Flex align="center" justify="space-between">
+            <Text fz="md" color="black" style={{ whiteSpace: 'nowrap' }}>
+              Subtotal &nbsp;&nbsp;&nbsp; $400.00
+            </Text>
+            <Button ml="20px" fullWidth style={{ color: 'black' }}>
+              View Cart
+            </Button>
+          </Flex>
+        </Menu.Label>
+      </Menu.Dropdown>
+    </Menu>
+  );
+};
+
+export default HeaderCart;

--- a/packages/ui/cart/HeaderCart.tsx
+++ b/packages/ui/cart/HeaderCart.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Anchor,
 } from '@mantine/core';
+import { StyledMenuDropdown, StyledMenuLabel } from './styles';
 import { TiShoppingCart } from 'react-icons/ti';
 import Cart from './Cart';
 
@@ -27,14 +28,11 @@ const HeaderCart: React.FC<IHeaderCartProps> = ({ cartItems }) => {
           <TiShoppingCart color="#fab005" size={36} />
         </UnstyledButton>
       </Menu.Target>
-      <Menu.Dropdown style={{ maxHeight: '575px', overflowY: 'auto' }}>
-        <Menu.Label
+      <StyledMenuDropdown>
+        <StyledMenuLabel
           style={{
             position: 'sticky',
             top: -4,
-            background: '#fff',
-            zIndex: 2,
-            padding: '10px 0px',
           }}
         >
           <Text fz="lg" color="black">
@@ -45,14 +43,14 @@ const HeaderCart: React.FC<IHeaderCartProps> = ({ cartItems }) => {
                   <Text>&nbsp;(4)</Text>
                 </Flex>
               </div>
-              <Anchor href="#" target="_blank">
+              <Anchor href="/#" target="_blank">
                 <Text fz="sm" color="yellow">
                   View all
                 </Text>
               </Anchor>
             </Flex>
           </Text>
-        </Menu.Label>
+        </StyledMenuLabel>
         <Menu.Divider />
         {cartItems.map((item) => (
           <Menu.Item key={item.id}>
@@ -65,13 +63,10 @@ const HeaderCart: React.FC<IHeaderCartProps> = ({ cartItems }) => {
           </Menu.Item>
         ))}
         <Menu.Divider />
-        <Menu.Label
+        <StyledMenuLabel
           style={{
             position: 'sticky',
-            bottom: -4,
-            background: '#fff',
-            zIndex: 2,
-            padding: '10px 0',
+            bottom: -5,
           }}
         >
           <Flex align="center" justify="space-between">
@@ -82,8 +77,8 @@ const HeaderCart: React.FC<IHeaderCartProps> = ({ cartItems }) => {
               View Cart
             </Button>
           </Flex>
-        </Menu.Label>
-      </Menu.Dropdown>
+        </StyledMenuLabel>
+      </StyledMenuDropdown>
     </Menu>
   );
 };

--- a/packages/ui/cart/HeaderCart.tsx
+++ b/packages/ui/cart/HeaderCart.tsx
@@ -22,7 +22,7 @@ interface IHeaderCartProps {
 }
 const HeaderCart: React.FC<IHeaderCartProps> = ({ cartItems }) => {
   return (
-    <Menu shadow="md" width={400}>
+    <Menu shadow="md" width={400} closeOnItemClick={false}>
       <Menu.Target>
         <UnstyledButton>
           <TiShoppingCart color="#fab005" size={36} />
@@ -71,7 +71,7 @@ const HeaderCart: React.FC<IHeaderCartProps> = ({ cartItems }) => {
         >
           <Flex align="center" justify="space-between">
             <Text fz="md" color="black" style={{ whiteSpace: 'nowrap' }}>
-              Subtotal &nbsp;&nbsp;&nbsp; $400.00
+              Subtotal &nbsp;&nbsp; ₱400.00
             </Text>
             <Button ml="20px" fullWidth style={{ color: 'black' }}>
               View Cart

--- a/packages/ui/cart/styles.ts
+++ b/packages/ui/cart/styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+import { Menu } from '@mantine/core';
+
+export const StyledMenuDropdown = styled(Menu.Dropdown)`
+  max-height: 575px;
+  overflow-y: auto;
+`;
+
+export const StyledMenuLabel = styled(Menu.Label)`
+  background: #fff;
+  z-index: 2;
+  padding: 10px 5px;
+`;

--- a/packages/ui/nav/Header.tsx
+++ b/packages/ui/nav/Header.tsx
@@ -16,11 +16,10 @@ import {
 import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 import { useState } from 'react';
 import { IoNotifications } from 'react-icons/io5';
-import { TiShoppingCart } from 'react-icons/ti';
 
 import { Dropdown } from '../dropdown/dropdown';
 import HeaderCart from '../cart/HeaderCart';
-import { AvatarContainer, CartTextWrapper } from './style';
+import { AvatarContainer } from './style';
 
 export const HeaderNavBar = () => {
   const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] =
@@ -32,7 +31,8 @@ export const HeaderNavBar = () => {
   const sampleCartItems = [
     {
       id: 1,
-      imageSrc: 'path-to-image-1.jpg',
+      imageSrc:
+        'https://retailminded.com/wp-content/uploads/2016/03/EN_GreenOlive-1.jpg',
       merchant: 'Sample Merchant 1',
       productName: 'Product 1',
       price: 200.0,
@@ -71,25 +71,6 @@ export const HeaderNavBar = () => {
               <Group position="right">
                 {verifyToken ? (
                   <>
-                    {/* <Dropdown
-                      target={
-                        <UnstyledButton>
-                          <TiShoppingCart color="#fab005" size={36} />
-                        </UnstyledButton>
-                      }
-                      menuItems={['Order 1', 'Order 2', 'Order 3']}
-                      avatarContent={
-                        <CartTextWrapper>
-                          <Text size="sm" weight={500}>
-                            My Cart (4)
-                          </Text>
-                          <Text size="xs" color="#fab005" weight={500}>
-                            View all
-                          </Text>
-                        </CartTextWrapper>
-                      }
-                    /> */}
-
                     <HeaderCart cartItems={sampleCartItems} />
 
                     <IoNotifications color="#fab005" size={36} />

--- a/packages/ui/nav/Header.tsx
+++ b/packages/ui/nav/Header.tsx
@@ -19,6 +19,7 @@ import { IoNotifications } from 'react-icons/io5';
 import { TiShoppingCart } from 'react-icons/ti';
 
 import { Dropdown } from '../dropdown/dropdown';
+import HeaderCart from '../cart/HeaderCart';
 import { AvatarContainer, CartTextWrapper } from './style';
 
 export const HeaderNavBar = () => {
@@ -26,6 +27,32 @@ export const HeaderNavBar = () => {
     useDisclosure(false);
   const [verifyToken, setVerifyToken] = useState<boolean>(true);
   const isMobile = useMediaQuery('(max-width: 976px)');
+
+  //Test data for cart
+  const sampleCartItems = [
+    {
+      id: 1,
+      imageSrc: 'path-to-image-1.jpg',
+      merchant: 'Sample Merchant 1',
+      productName: 'Product 1',
+      price: 200.0,
+    },
+    {
+      id: 2,
+      imageSrc: 'path-to-image-2.jpg',
+      merchant: 'Sample Merchant 2',
+      productName: 'Product 2',
+      price: 150.0,
+    },
+    {
+      id: 3,
+      imageSrc: 'path-to-image-2.jpg',
+      merchant: 'Sample Merchant 3',
+      productName: 'Product 2',
+      price: 250.0,
+    },
+    // Add more items as needed to test
+  ];
 
   return (
     <Box>
@@ -44,7 +71,7 @@ export const HeaderNavBar = () => {
               <Group position="right">
                 {verifyToken ? (
                   <>
-                    <Dropdown
+                    {/* <Dropdown
                       target={
                         <UnstyledButton>
                           <TiShoppingCart color="#fab005" size={36} />
@@ -61,7 +88,9 @@ export const HeaderNavBar = () => {
                           </Text>
                         </CartTextWrapper>
                       }
-                    />
+                    /> */}
+
+                    <HeaderCart cartItems={sampleCartItems} />
 
                     <IoNotifications color="#fab005" size={36} />
                     <Dropdown
@@ -120,7 +149,7 @@ export const HeaderNavBar = () => {
           )}
           {isMobile && (
             <Group position="right">
-              <TiShoppingCart color="#fab005" size={30} />
+              <HeaderCart cartItems={sampleCartItems} />
               <IoNotifications color="#fab005" size={30} />
               <Burger opened={drawerOpened} onClick={toggleDrawer} size="sm" />
             </Group>

--- a/packages/ui/nav/Header.tsx
+++ b/packages/ui/nav/Header.tsx
@@ -16,7 +16,7 @@ import {
 import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 import { useState } from 'react';
 import { IoNotifications } from 'react-icons/io5';
-
+import { TiShoppingCart } from 'react-icons/ti';
 import { Dropdown } from '../dropdown/dropdown';
 import HeaderCart from '../cart/HeaderCart';
 import { AvatarContainer } from './style';
@@ -130,7 +130,9 @@ export const HeaderNavBar = () => {
           )}
           {isMobile && (
             <Group position="right">
-              <HeaderCart cartItems={sampleCartItems} />
+              <UnstyledButton>
+                <TiShoppingCart color="#fab005" size={36} />
+              </UnstyledButton>
               <IoNotifications color="#fab005" size={30} />
               <Burger opened={drawerOpened} onClick={toggleDrawer} size="sm" />
             </Group>


### PR DESCRIPTION
## Ticket/s

- [Cart Dropdown View](https://trello.com/c/u7CDrYvL/52-cart-dropdown-view)

## Changes

- Created component per cart object
- Replaced old cart dropdown placeholder with HeaderCart component
- Allows passing of cartItem object to use for rendering the cart component multiple cart items
- Scrollable cart for multiple cart items

_To do: 
-if screen isMobile, do we still show dropdown or redirect to cart page?_

## Screenshot
![image](https://github.com/dandalandone/POC-EyCommerce/assets/132859942/2c3c536f-3585-4129-8a7d-196c035e0f8d)

- add GIF or screenshot here

## How to test?

- pnpm run dev and load in browser
- See packages/ui/nav/Header.tsx and replace or add test data.
