### PR TITLE
[FIX] [BACKEND] - Create Product Rating API fix

### DIFF
--- a/apps/api/src/order/order.service.ts
+++ b/apps/api/src/order/order.service.ts
@@ -29,11 +29,13 @@ export class OrderService {
   }
 
   async findOrder(orderId: string, req: any): Promise<Order> {
+    const userId = await this.usersService.findUser(req);
     const order = await this.orderModel.findOne({ _id: orderId });
 
-    if (req._id.toString() !== order.userId.toString()) {
+    if (userId._id.toString() !== order.userId.toString()) {
       throw new UnauthorizedException('User is unauthorized!');
     }
+
     if (!order) {
       throw new NotFoundException('Order is not found');
     }
@@ -156,11 +158,12 @@ export class OrderService {
   }
 
   async cancelOrder(request: any, id: string): Promise<Order> {
+    const userId = await this.usersService.findUser(request);
     const order = await this.orderModel.findById(id);
     if (!order) {
       throw new NotFoundException('Order not found');
     }
-    if (request._id.toString() !== order.userId.toString()) {
+    if (userId._id.toString() !== order.userId.toString()) {
       throw new ForbiddenException('You are not allowed to cancel this order');
     }
 

--- a/apps/api/src/order/order.service.ts
+++ b/apps/api/src/order/order.service.ts
@@ -28,16 +28,17 @@ export class OrderService {
     return await this.orderModel.find({ userId: user._id.toString() });
   }
 
+  // may error dito regarding sa non existingId -- wala pa error handling
   async findOrder(orderId: string, req: any): Promise<Order> {
     const userId = await this.usersService.findUser(req);
     const order = await this.orderModel.findOne({ _id: orderId });
 
-    if (userId._id.toString() !== order.userId.toString()) {
-      throw new UnauthorizedException('User is unauthorized!');
+    if (!order) {
+      throw new NotFoundException('Order not found');
     }
 
-    if (!order) {
-      throw new NotFoundException('Order is not found');
+    if (userId._id.toString() !== order.userId.toString()) {
+      throw new UnauthorizedException('User is unauthorized!');
     }
 
     return order;

--- a/apps/api/src/order/order.service.ts
+++ b/apps/api/src/order/order.service.ts
@@ -28,7 +28,6 @@ export class OrderService {
     return await this.orderModel.find({ userId: user._id.toString() });
   }
 
-  // may error dito regarding sa non existingId -- wala pa error handling
   async findOrder(orderId: string, req: any): Promise<Order> {
     const userId = await this.usersService.findUser(req);
     const order = await this.orderModel.findOne({ _id: orderId });

--- a/apps/api/src/rating/dto/create-rating.dto.ts
+++ b/apps/api/src/rating/dto/create-rating.dto.ts
@@ -15,4 +15,6 @@ export class CreateRatingDto {
 
   @IsString()
   readonly description: string;
+
+  readonly orderId;
 }

--- a/apps/api/src/rating/rating.controller.ts
+++ b/apps/api/src/rating/rating.controller.ts
@@ -22,19 +22,20 @@ export class RatingController {
     private readonly userService: UsersService,
   ) {}
 
+  @HttpCode(HttpStatus.CREATED)
+  @Post('/:id')
+  async createRating(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Body() createRatingDto: CreateRatingDto,
+  ): Promise<Rating> {
+    return await this.ratingService.createRating(req._id, id, createRatingDto);
+  }
+
   @HttpCode(HttpStatus.OK)
   @Get('/:id')
   async getProductRatings(@Param('id') productId: string): Promise<Rating[]> {
     return await this.ratingService.getProductRatings(productId);
-  }
-
-  @HttpCode(HttpStatus.CREATED)
-  @Post('')
-  async create(
-    @Req() req: any,
-    @Body() createRatingDto: CreateRatingDto,
-  ): Promise<Rating> {
-    return await this.ratingService.createOrderRating(req._id, createRatingDto);
   }
 
   @HttpCode(HttpStatus.OK)

--- a/apps/api/src/rating/rating.service.ts
+++ b/apps/api/src/rating/rating.service.ts
@@ -90,7 +90,6 @@ export class RatingService {
     const now = new Date();
     const rating = {
       ...createRatingDto,
-      userId,
       username: userId.auth.username,
       publishedDate: now,
       reviewDate: now,

--- a/apps/api/src/rating/schemas/rating.schema.ts
+++ b/apps/api/src/rating/schemas/rating.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, SchemaTypes } from 'mongoose';
+import { Order } from 'src/order/schemas/order.schema';
 import { Product } from 'src/products/schemas/products.schema';
 import { User } from 'src/users/schemas/user.schema';
 
@@ -30,6 +31,9 @@ export class Rating {
 
   @Prop({ default: Date.now })
   reviewDate: Date;
+
+  @Prop({ type: SchemaTypes.ObjectId, ref: Order.name })
+  orderId: string;
 }
 
 export const RatingSchema = SchemaFactory.createForClass(Rating);


### PR DESCRIPTION
## Ticket/s

- [[API] Create Product Rating](https://trello.com/c/NRhiuXzC/42-api-create-product-rating)

## Changes

- fix findOrder and cancelOrder
- create rating API v2
- allows users to **rate product again** as long as it is from **different order**

## Screenshot

- Rate products if `status` is **delivered**:

![image](https://github.com/TreshAnn/POC-EyCommerce/assets/129832182/5efce572-a800-442e-82b0-531687877deb)

![image](https://github.com/TreshAnn/POC-EyCommerce/assets/129832182/5d61d706-79e8-4e46-881e-c2c3e124cd90)

![image](https://github.com/TreshAnn/POC-EyCommerce/assets/129832182/8c1ff381-7665-416f-beca-c8d64404382d)


<br />

- **Cannot** rate `productId` again (within same order)

![image](https://github.com/TreshAnn/POC-EyCommerce/assets/129832182/7a4a536c-4b0b-498b-a529-bdb9940ffc05)

<br />

- Checks if `productId` exists in order

![image](https://github.com/TreshAnn/POC-EyCommerce/assets/129832182/25492a65-b108-4bc8-9f47-12cd7e1100de)

<br />

- Can rate `productId` again as long as it is from other order

- same `productId`, different `orderId`

![image](https://github.com/TreshAnn/POC-EyCommerce/assets/129832182/4e9eed97-8f87-4a42-883a-3534bffdee16)

![image](https://github.com/TreshAnn/POC-EyCommerce/assets/129832182/f3f11e63-d7e5-4387-b781-ab069b60c3c7)

![image](https://github.com/TreshAnn/POC-EyCommerce/assets/129832182/7051f5a2-7943-4f67-9b52-5e5608c5bd64)


## How to test?

- Open Postman
- create order - https://github.com/TreshAnn/POC-EyCommerce/pull/110
- create Rating
```
curl --location 'localhost:3001/api/rating/<insert orderId here>' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <insert token here>' \
--data '{
    "productId": "<insert productId from order here>",
    "rating": 5,
    "title": "rating title",
    "description": "rating description"
}
'
```